### PR TITLE
Add error and check for zero amount in migrate

### DIFF
--- a/src/MigrateHLGToGAINS.sol
+++ b/src/MigrateHLGToGAINS.sol
@@ -10,6 +10,7 @@ import "./GAINS.sol";
  */
 contract MigrateHLGToGAINS {
     error ZeroAddressInConstructor();
+    error ZeroAmount();
     error BurnFromFailed();
 
     /**
@@ -47,6 +48,10 @@ contract MigrateHLGToGAINS {
      * @param amount The amount of HLG to burn and convert.
      */
     function migrate(uint256 amount) external {
+        if (amount == 0) {
+            revert ZeroAmount();
+        }
+
         // @notice The user must have approved the HLG contract before calling.
         if (!hlg.burnFrom(msg.sender, amount)) {
             revert BurnFromFailed();

--- a/test/foundry/MigrateHLGToGAINS.t.sol
+++ b/test/foundry/MigrateHLGToGAINS.t.sol
@@ -82,14 +82,10 @@ contract MigrateHLGToGAINSTest is Test {
         setUpMigrationContract();
         vm.startPrank(alice);
         hlg.approve(address(migration), 0);
-        uint256 preHLGBalance = hlg.balanceOf(alice);
-        uint256 preGAINSBalance = gains.balanceOf(alice);
 
+        vm.expectRevert(MigrateHLGToGAINS.ZeroAmount.selector);
         migration.migrate(0);
 
-        // Balances should remain unchanged
-        assertEq(hlg.balanceOf(alice), preHLGBalance);
-        assertEq(gains.balanceOf(alice), preGAINSBalance);
         vm.stopPrank();
     }
 

--- a/test/foundry/MigrateHLGToGAINSFork.t.sol
+++ b/test/foundry/MigrateHLGToGAINSFork.t.sol
@@ -228,17 +228,8 @@ contract MigrateHLGToGAINSFork is TestHelperOz5 {
         IERC20(SEP_HLG).approve(address(migration), hlgAmount);
 
         // Perform migration
-        migration.migrate(hlgAmount);
-
-        // Post-migration checks
-        uint256 deployerGainsBal = gains.balanceOf(deployer);
-        uint256 deployerHLGBal = IERC20(SEP_HLG).balanceOf(deployer);
-
-        // Verify balances unchanged
-        // If deployer had zero GAINS pre-migration, it remains zero.
-        // If deployer had some HLG pre-migration, it remains unchanged.
-        assertEq(deployerGainsBal, gains.balanceOf(deployer));
-        assertEq(deployerHLGBal, IERC20(SEP_HLG).balanceOf(deployer));
+        vm.expectRevert(MigrateHLGToGAINS.ZeroAmount.selector);
+        migration.migrate(0);
 
         vm.stopPrank();
     }


### PR DESCRIPTION
# Prevent Zero Amount Migration

## Overview
Added validation to prevent migrations with zero tokens, which would waste gas and create unnecessary transaction records. 

Resolves: https://github.com/zenith-security/2025-01-holograph-zenith/issues/4

## Changes
- Added `ZeroAmount` error in `MigrateHLGToGAINS` contract
- Added validation check in `migrate()` function
- Updated tests to verify zero amount migrations revert properly

## Test Coverage
- Added test cases for zero amount validation in both unit and fork tests
- All existing tests pass

## Security Considerations
- Prevents users from executing pointless and / or spam zero-amount migrations
- Saves users from unnecessary gas costs