### PR TITLE
Add pausable to migration contract

### DIFF
--- a/src/MigrateHLGToGAINS.sol
+++ b/src/MigrateHLGToGAINS.sol
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
+import "@openzeppelin/contracts/utils/Pausable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "./interfaces/HolographERC20Interface.sol";
 import "./GAINS.sol";
 
 /**
  * @title MigrateHLGToGAINS
  * @notice Burns HLG from a user, then mints GAINS (OFT) to the same user 1:1.
+ * @dev Includes pause functionality to disable migration if needed.
  */
-contract MigrateHLGToGAINS {
+contract MigrateHLGToGAINS is Pausable, Ownable {
     error ZeroAddressInConstructor();
     error ZeroAmount();
     error BurnFromFailed();
@@ -34,7 +37,7 @@ contract MigrateHLGToGAINS {
      * @param _hlg Address of the deployed HLG (HolographUtilityToken) contract proxy.
      * @param _gains Address of the deployed GAINS (OFT) contract.
      */
-    constructor(address _hlg, address _gains) {
+    constructor(address _hlg, address _gains) Ownable(msg.sender) {
         if (_hlg == address(0) || _gains == address(0)) {
             revert ZeroAddressInConstructor();
         }
@@ -43,11 +46,27 @@ contract MigrateHLGToGAINS {
     }
 
     /**
+     * @notice Pauses the migration functionality.
+     * @dev Only callable by the owner.
+     */
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /**
+     * @notice Unpauses the migration functionality.
+     * @dev Only callable by the owner.
+     */
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    /**
      * @notice Migrate the caller's HLG into GAINS 1:1.
-     * @dev The caller must first approve this contract on HLG for `amount`.
+     * @dev The caller must first approve this contract on HLG for `amount`. Function is disabled when paused.
      * @param amount The amount of HLG to burn and convert.
      */
-    function migrate(uint256 amount) external {
+    function migrate(uint256 amount) external whenNotPaused {
         if (amount == 0) {
             revert ZeroAmount();
         }
@@ -57,7 +76,7 @@ contract MigrateHLGToGAINS {
             revert BurnFromFailed();
         }
 
-        // Mint GAINS 1:1 to the caller
+        // Mint GAINS 1:1 to the caller.
         gains.mintForMigration(msg.sender, amount);
 
         emit MigratedHLGToGAINS(msg.sender, amount);


### PR DESCRIPTION
# 🛑 Add Pausable to Migration Contract

Resolves: https://github.com/zenith-security/2025-01-holograph-zenith/issues/5

## Changes
- Added OpenZeppelin's `Pausable` and `Ownable` to the migration contract
- Implemented pause/unpause functionality accessible only by the contract owner
- Added test coverage for pause mechanisms
- Migration function is now protected with `whenNotPaused` modifier

## Security
- Only the contract owner can pause/unpause migrations
- Adds emergency stop capability if issues are detected during migration process
- Maintains existing security checks and 1:1 migration ratio

## Testing
Added new test suite for pause functionality including:
- Verification that paused state prevents migrations
- Confirmation that unpausing re-enables migrations
- Access control tests for pause/unpause functions